### PR TITLE
Fix README.md Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Information:
 
-- Designed for 10.5+
+- Designed for 10.15+
 - This plugin enables unsupported iPads to be used as a sidecar display
 - Some iPads may require wired connect
 - Currently supported iPads: 


### PR DESCRIPTION
The PR fixes a presumable typo in the readme file: in the titletext Musclecar is listed for 10.15+, but 10.5+ was listed in Information.